### PR TITLE
Fix bug due to TouchEvents listeners default to passive

### DIFF
--- a/src/burgermenu.js
+++ b/src/burgermenu.js
@@ -49,7 +49,7 @@
 
     $el.find('.active').closest('.burgermenu-panel').addClass('opened');
 
-    $document.on('click touchstart', '#burgermenu-blocker, ' + opts.toggle_selector, function(e) {
+    $document.on('click', '#burgermenu-blocker, ' + opts.toggle_selector, function(e) {
       e.preventDefault();
       e.stopPropagation();
       $el.trigger('burgermenu.toggle');

--- a/src/burgermenu.scss
+++ b/src/burgermenu.scss
@@ -103,6 +103,7 @@ body {
   top: 0;
   left: 0;
   z-index: 999999;
+  cursor: pointer;
 }
 
 .burgermenu-sticky-head {


### PR DESCRIPTION
- Remove touchstart event attached to document.
More info:
https://www.chromestatus.com/feature/5093566007214080

- Add `cursor: pointer` to the blocker layer to fix bug in ios

🤗 🤗 🤗 🤗 🤗 🤗 🤗 🤗 🤗 